### PR TITLE
buildstrap: execute build-bcc.sh on the host using chroot

### DIFF
--- a/androdeb
+++ b/androdeb
@@ -361,11 +361,6 @@ $ADB push $TDIR/deb.tar.gz /data/androdeb/
 $ADB push $spath/addons/* /data/androdeb/
 $ADB shell /data/androdeb/device-unpack
 
-# Build BCC and install bcc on device if needed
-if [ $INSTALL_BCC -eq 1 ]; then
-	$ADB shell /data/androdeb/run-command /bcc-master/build-bcc.sh;
-fi
-
 # Extract a tar of the built, compiled and installed androdeb env
 if [[ ! -z ${TARDIR+x} ]]; then
 	c_info "Creating tarball"

--- a/buildstrap
+++ b/buildstrap
@@ -62,10 +62,11 @@ echo "nameserver 4.2.2.2" > $OUT_TMP/etc/resolv.conf
 # Clone BCC if needed
 if [ $INSTALL_BCC -eq 1 ]; then
 	git clone https://github.com/iovisor/bcc.git $TDIR/debian/bcc-master
-	cp $spath/bcc/build-bcc.sh $TDIR/debian/bcc-master/;
+	cp $spath/bcc/build-bcc.sh $TDIR/debian/bcc-master/
+	chroot $OUT_TMP /bcc-master/build-bcc.sh
 fi
 
-# Should be really do this?
+# Should we really do this?
 chmod -R 0777 $TDIR/
 
 [ $SKIP_DEVICE -eq 0 ] || exit 0


### PR DESCRIPTION
When chrooting into a debian image that was created for a different arch
the system will look like it's executing on that arch and we can do the
compilation directly from this env as if we were running natively on
that arch. Debian recognizes the arch difference and might be using qemu
directly behind the scene. Not entirely sure on the exact mechanisms
deployed here but have used this trick several times in the past.

Also fix a typo s/be/we/

Signed-off-by: Qais Yousef <qais.yousef@arm.com>