### PR TITLE
Build bcc for Python 3

### DIFF
--- a/bcc/build-bcc.sh
+++ b/bcc/build-bcc.sh
@@ -8,5 +8,10 @@ rm -rf build && mkdir -p build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_C_COMPILER=clang-7 -DCMAKE_CXX_COMPILER=clang++-7
 make -j4
 make install
+cmake -DPYTHON_CMD=python3 ..
+pushd src/python/
+make
+make install
+popd
 cd ..
 rm -rf build

--- a/packages/bcc
+++ b/packages/bcc
@@ -20,6 +20,7 @@ python
 clang-7
 python-netaddr
 python-pyroute2
+python3-distutils
 "
 
 INSTALL_BCC=1

--- a/packages/others
+++ b/packages/others
@@ -1,0 +1,3 @@
+PACKAGES+="\
+xz-utils
+"


### PR DESCRIPTION
This PR installs bcc for Python 3 in addition to Python 2.