### PR TITLE
Adding mount point for /dev/binderfs if needed

### DIFF
--- a/addons/run.common
+++ b/addons/run.common
@@ -36,6 +36,12 @@ do_mounts()
 		mkdir -p debian/vendor/
 		mount --bind /vendor debian/vendor/
 	fi
+
+  if [ -d /dev/binderfs/ ]; then
+    mkdir -p debian/dev/binderfs
+    mount --bind /dev/binderfs/ debian/dev/binderfs
+  fi
+
 }
 
 mount | grep debian > /dev/null


### PR DESCRIPTION
This is a simple edit to add support for Cuttlefish. 

Certain versions of android use an additional bind point for binder, in particular /dev/binderfs/*, but this is yet another mount point. 